### PR TITLE
Fix possible license issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='1.0.6',
     packages=['lightify'],
     include_package_data=True,
-    license='BSD License',
+    license='Apache License (2.0)',
     description='A library to work with OSRAM lightify.',
     long_description='A library to work with OSRAM lightify. Threadsafe.',
     url='https://github.com/tfriedel/python-lightify',


### PR DESCRIPTION
Tracing back the forks I see some license problems.
- https://github.com/tfriedel/python-lightify => License file stating Apache-2.0, setup.py stating BSD
- https://github.com/aneumeier/python-lightify   => License file stating Apache-2.0, setup.py stating BSD
- https://github.com/mikma/python-lightify => License file stating Apache-2.0

As the original fork by @mikma was Apache-2.0 I assume the original code was Apache-2.0.

So if all contributors agree I suggest clarifying this in putting the code completly under Apache-2.0 license.

This PR fixes this in the setup.py, please feel free to accept it if you aggree.